### PR TITLE
struct perm will be accessible to users

### DIFF
--- a/include/permutations.h
+++ b/include/permutations.h
@@ -4,11 +4,17 @@
 #include <stdint.h>
 
 /* a more fitting name for the operation */
-typedef int8_t byte;
+typedef uint8_t byte;
 
-/* users should interact w/ the group through the api
- * functions */
-typedef struct perm *permptr;
+struct perm
+{
+    void *collection;
+    uint64_t height;
+    uint8_t width;
+    uint32_t objsize;
+};
+typedef struct perm
+perm;
 
 /* all of these functions will allocate memory for a new 
  * container of size (width * sizeof(object)) * (height) =
@@ -17,9 +23,6 @@ typedef struct perm *permptr;
  *
  * These must be freed by the caller.
  */
-
-/**/
-void kill_perm(permptr p);
 
 /* permutes the array such that both the elements
  * and the ordering are unique. i.e. only one of
@@ -31,15 +34,15 @@ void kill_perm(permptr p);
  * [1,2,3] would be shown rather over [3,2,1] whereas
  * for nCkperm([3,4,2,1], 4, 3) [3,2,1] would be shown.
  */
-permptr nCkperm(void *collection, uint8_t n, uint8_t k, uint64_t objsize);
+perm nCkperm(void *collection, uint8_t n, uint8_t k, uint64_t objsize);
 
 /**/
 void *cycle(void *collection, uint64_t n, uint64_t k, uint64_t objsize);
 
 /**/
-permptr permutations(void *collection, uint64_t n, uint64_t k, uint64_t objsize);
+perm permutations(void *collection, uint64_t n, uint64_t k, uint64_t objsize);
 
 /**/
-void printPerm(permptr group, void (*prettyPrint)(void *));
+void printPerm(perm group, void (*prettyPrint)(void *));
 
 #endif /* _PERMUTATIONS_H_ */

--- a/src/permutations.c
+++ b/src/permutations.c
@@ -3,32 +3,6 @@
 #include "permutations.h"
 #include "combinatorics.h"
 
-struct perm
-{
-    void *collection;
-    uint64_t height;
-    uint8_t width;
-    uint32_t objsize;
-};
-typedef struct perm
-perm;
-
-permptr birth_perm(uint64_t height, uint8_t width, uint32_t objsize)
-{
-    permptr new = malloc(sizeof(perm));
-    new->collection = (void *)0;
-    new->height = height;
-    new->width = width;
-    new->objsize = objsize;
-    return new;
-}
-
-void kill_perm(permptr p)
-{
-    free(p->collection);
-    free(p);
-}
-
 void swap(int *rowN, int k, int counters[], byte *collection, byte *perm, uint64_t objsize)
 {
     for (int iter = 0; iter < k; ++iter)
@@ -57,13 +31,12 @@ void enumerate(int *rowN, int ijk, int k, int counters[k], int ijk_ends[k], byte
     return;
 }
 
-permptr nCkperm(void *collection, uint8_t n, uint8_t k, uint64_t objsize)
+perm nCkperm(void *collection, uint8_t n, uint8_t k, uint64_t objsize)
 {
     uint64_t height = choose(n, k);
-    permptr group = birth_perm(height, k, objsize);
     
     // byte * enables manipulation of objs
-    byte *perm = malloc(height * k * objsize);
+    byte *group = malloc(height * k * objsize);
 
     // setup loop variables for recursion
     int counters[k], ijk_ends[k], rowN = 0;
@@ -73,11 +46,9 @@ permptr nCkperm(void *collection, uint8_t n, uint8_t k, uint64_t objsize)
         ijk_ends[i] = n - k + i + 1;
     }
 
-    enumerate(&rowN, 0, k, counters, ijk_ends, collection, perm, objsize);
+    enumerate(&rowN, 0, k, counters, ijk_ends, collection, group, objsize);
 
-    group->collection = perm;
-
-    return group;
+    return (perm){.collection = group, .width = k, .height = height, .objsize = objsize};
 }
 
 // TODO
@@ -90,11 +61,11 @@ void *cycle(void *collection, uint64_t n, uint64_t k, uint64_t objsize)
 }
 
 // TODO
-permptr permutations(void *collection, uint64_t n, uint64_t k, uint64_t objsize)
+perm permutations(void *collection, uint64_t n, uint64_t k, uint64_t objsize)
 {
     // PHONY:
     n += k * objsize;
-    return collection;
+    return (perm){.collection = collection};
     // END PHONY
 }
 
@@ -104,15 +75,15 @@ permptr permutations(void *collection, uint64_t n, uint64_t k, uint64_t objsize)
 
 #include <stdio.h>
 
-void printPerm(permptr group, void (*prettyPrint)(void *)){
+void printPerm(perm group, void (*prettyPrint)(void *)){
     printf("[\n");
-    for (int i = 0; i < group->height; ++i){
+    for (uint i = 0; i < group.height; ++i){
         printf("[");
-        for (int j =0; j < group->width; ++j){
-            prettyPrint( (void *)&((byte *)group->collection)[ (i * group->width + j) * group->objsize] );
-            printf("%s", j < group->width - 1 ? ", ": "");
+        for (uint j = 0; j < group.width; ++j){
+            prettyPrint( (void *)&((byte *)group.collection)[ (i * group.width + j) * group.objsize] );
+            printf("%s", j < group.width - 1u ? ", ": "");
         }
-        printf("]%s\n", i < group->height - 1 ? ",": "");
+        printf("]%s\n", i < group.height - 1 ? ",": "");
     }
     printf("]\n");
 }


### PR DESCRIPTION
An opaque pointer to a permuatation is practically useless. It allocates more memory unnecessarily and is a hassle. Custom getters would still have users using loops with the struct anyway. The transparent struct makes sense.